### PR TITLE
Add UDP sniffer helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ To use OpenBR24, follow these steps:
 
 ### Live Radar Setup
 
+The GUI listens on UDP port `50102` for datagrams coming directly from the radar.
+Ensure your computer is on the same network segment so the packets reach that
+port. If you need to confirm that data is arriving, use the helper script:
+
+```bash
+python scripts/udp_sniffer.py
+```
+
+It prints each received packet along with the source address and size.
+
 ## Installation
 
 ### Prerequisites

--- a/scripts/udp_sniffer.py
+++ b/scripts/udp_sniffer.py
@@ -1,0 +1,22 @@
+import socket
+import datetime
+
+PORT = 50102
+BUFFER_SIZE = 65535
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(('', PORT))
+
+print(f"Listening for UDP packets on port {PORT}...")
+
+try:
+    while True:
+        data, addr = sock.recvfrom(BUFFER_SIZE)
+        timestamp = datetime.datetime.now().isoformat()
+        hexdata = data.hex()
+        print(f"[{timestamp}] {addr[0]}:{addr[1]} {len(data)} bytes")
+        print(hexdata)
+except KeyboardInterrupt:
+    pass
+finally:
+    sock.close()


### PR DESCRIPTION
## Summary
- add `udp_sniffer.py` helper script
- document UDP port listening and sniffer usage in README

## Testing
- `python3 scripts/udp_sniffer.py` *(no packets observed)*

------
https://chatgpt.com/codex/tasks/task_e_685311660c68832095c63f80b3e5515f