### PR TITLE
Enable forwarding from Python sniffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,17 @@ To use OpenBR24, follow these steps:
 
 ### Live Radar Setup
 
-The GUI listens on UDP port `50102` for datagrams coming directly from the radar.
-Ensure your computer is on the same network segment so the packets reach that
-port. If you need to confirm that data is arriving, use the helper script:
+The GUI listens on UDP port `6678` for datagrams. If your radar sends unicast
+packets, the provided Python script can sniff them from the network interface
+and forward them to this multicast port so the Java GUI receives them.
+
+Run the helper script with:
 
 ```bash
 python scripts/udp_sniffer.py
 ```
 
-It prints each received packet along with the source address and size.
+The script will display each captured packet and forward it to the GUI.
 
 ## Installation
 

--- a/scripts/udp_sniffer.py
+++ b/scripts/udp_sniffer.py
@@ -1,4 +1,5 @@
 from scapy.all import sniff, UDP, IP
+import socket
 import threading
 
 # ========== CONFIG ==========
@@ -8,6 +9,14 @@ RUNNING = True
 
 TARGET_PORTS = {6678}
 TARGET_IPS = {"236.6.7.8", "236.6.7.9", "236.6.7.10", "236.6.7.11"}
+
+# Forwarding configuration so the Java GUI can receive the packets
+FORWARD_ADDR = "236.6.7.8"   # Multicast group that the GUI listens on
+FORWARD_PORT = 6678
+SRC_IP = "169.254.74.24"      # Local interface used to send the packets
+SRC_PORT = 38071
+_forward_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+_forward_sock.bind((SRC_IP, SRC_PORT))
 
 # ========== PACKET HANDLER ==========
 def packet_callback(packet):
@@ -23,6 +32,9 @@ def packet_callback(packet):
             print(f"[Simrad] {src_ip} → {dst_ip}:{dst_port} | {len(payload)} bytes")
             if DEBUG:
                 print(payload.hex(" ", 1))
+            # forward the raw payload to the multicast group so the Java GUI can
+            # receive and decode the radar data in real time
+            _forward_sock.sendto(payload, (FORWARD_ADDR, FORWARD_PORT))
 
 # ========== STOP LISTENER THREAD ==========
 def wait_for_enter():


### PR DESCRIPTION
## Summary
- modify `udp_sniffer.py` to forward captured packets to the GUI
- document running the sniffer for live radar setup

## Testing
- `python -m py_compile scripts/udp_sniffer.py`

------
https://chatgpt.com/codex/tasks/task_e_685318e084dc83209365c79a1dc5aad2