### PR TITLE
Add live UDP radar source

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ To use OpenBR24, follow these steps:
 
 ### Live Radar Setup
 
-The GUI listens on UDP port `6678` for datagrams. If your radar sends unicast
-packets, the provided Python script can sniff them from the network interface
-and forward them to this multicast port so the Java GUI receives them.
+The GUI listens on UDP port `6678` for datagrams. It can now decode packets
+directly from this port in real time. If your radar sends the data to a
+different address, you can still use the helper script below to forward the
+packets to port `6678` for the GUI.
 
 Run the helper script with:
 

--- a/src/at/innoc/roboat/radar/GUI.java
+++ b/src/at/innoc/roboat/radar/GUI.java
@@ -27,6 +27,7 @@ import java.net.UnknownHostException;
 
 import at.innoc.roboat.radar.control.LiveControl;
 import at.innoc.roboat.radar.control.ZoomLevel;
+import at.innoc.roboat.radar.RadarUdpSource;
 import javax.swing.JScrollPane;
 import javax.swing.BorderFactory;
 import java.awt.SystemColor;
@@ -270,8 +271,8 @@ public class GUI extends JFrame implements RadarRendererListener {
 				public void actionPerformed(java.awt.event.ActionEvent e) {
 					try {				
 						//control.Power(true);
-						radarsource=new RadarLiveSource(control);
-						radarrenderer=new RadarRenderer(radarsource, radarlistener);
+                                               radarsource=new RadarUdpSource(control);
+                                               radarrenderer=new RadarRenderer(radarsource, radarlistener);
 					} catch (UnknownHostException e1) {
 						e1.printStackTrace();
 					} catch (IOException e1) {

--- a/src/at/innoc/roboat/radar/RadarUdpSource.java
+++ b/src/at/innoc/roboat/radar/RadarUdpSource.java
@@ -1,0 +1,82 @@
+package at.innoc.roboat.radar;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.net.UnknownHostException;
+
+import at.innoc.roboat.radar.control.LiveControl;
+import at.innoc.roboat.radar.helpers.IpHelper;
+
+public class RadarUdpSource implements RadarSource, Runnable {
+        private DatagramSocket socket;
+        private DatagramPacket datagram;
+        private static Thread keepAliveThread = null;
+        private static boolean keepAliveStop;
+        private static LiveControl control;
+
+        public RadarUdpSource(LiveControl controlchannel) throws UnknownHostException, IOException {
+                this(controlchannel, 6678);
+        }
+
+        public RadarUdpSource(LiveControl controlchannel, int port) throws UnknownHostException, IOException {
+                control = controlchannel;
+                try {
+                        Object[] result = IpHelper.getMachineIp();
+                        if (result[0] == null) {
+                                throw new UnknownHostException((String) result[1]);
+                        }
+                        InetAddress interfaceAddress = InetAddress.getByName((String) result[0]);
+                        socket = new DatagramSocket(new InetSocketAddress(interfaceAddress, port));
+                } catch (UnknownHostException e) {
+                        e.printStackTrace();
+                } catch (IOException e) {
+                        e.printStackTrace();
+                }
+
+                datagram = new DatagramPacket(new byte[80000], 80000);
+                keepAliveStop = false;
+                if (keepAliveThread == null) {
+                        keepAliveThread = new Thread(this);
+                        keepAliveThread.setDaemon(true);
+                        keepAliveThread.start();
+                }
+        }
+
+        @Override
+        public RadarDataFrame getNextDataFrame() {
+                byte[] ret;
+                try {
+                        socket.receive(datagram);
+                        long time = System.currentTimeMillis();
+                        ret = java.util.Arrays.copyOfRange(datagram.getData(), datagram.getOffset(), datagram.getLength());
+                        return new RadarDataFrame(ret, time);
+                } catch (SocketException se) {
+                        System.out.println(se + "");
+                        return new RadarDataFrame();
+                } catch (IOException e) {
+                        e.printStackTrace();
+                        return new RadarDataFrame();
+                }
+        }
+
+        @Override
+        public void close() {
+                keepAliveStop = true;
+                socket.close();
+        }
+
+        @Override
+        public void run() {
+                while (!keepAliveStop) {
+                        try {
+                                Thread.sleep(1000);
+                                control.sendKeepAlive();
+                        } catch (Exception e) {
+                        }
+                }
+        }
+}


### PR DESCRIPTION
## Summary
- support reading radar packets directly from UDP port 6678
- expose new `RadarUdpSource` and use it when opening live view
- document real-time UDP decoding in README

## Testing
- `javac -cp lib/jnetpcap/jnetpcap.jar -d bin @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68531a5c45dc832089737c718f84fa07